### PR TITLE
Fix fence recipe

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -1329,11 +1329,10 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = "default:fence 2",
+	output = "default:fence_wood 2",
 	recipe = {
-		{"", "", ""},
-		{"default:wood", "default:wood", "default:wood"},
-		{"default:wood", "default:wood", "default:wood"},
+		{"default:stick", "default:stick", "default:stick"},
+		{"default:stick", "default:stick", "default:stick"},
 	}
 })
 


### PR DESCRIPTION
The recipe for fences is broken atm. This PR fixes the recipe, and swaps out wood for sticks, to make it more accurate with [the recipe of the time](http://packages.8dromeda.net/minetest/websites/minetest-bak-2011-12-01/wiki/doku.php%3Fid=crafting.html#fence). :)