### PR TITLE
Allow users to disable mob griefing

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -9,6 +9,9 @@
 # If enabled, hostile mobs immediately despawn.
 #only_peaceful_mobs = false
 
+# If enabled, hostile mobs will not damage the terrain.
+#no_mob_griefing = false
+
 # The modernize flags control various behaviours in Minetest Classic that
 # (when a flag is enabled) differ from how Minetest-c55 0.3 would have behaved.
 # By default a conservative but reasonable compromise between faithfulness and

--- a/mods/default/sao.lua
+++ b/mods/default/sao.lua
@@ -865,7 +865,7 @@ function MobV2SAO:on_step(dtime, moveresult)
 				}, true)
 			end
 
-			if core.settings:get("no_mob_griefing") ~= "true" then
+			if not core.settings:get_bool("no_mob_griefing", false) then
 				explodeSquare(pos_i, vector.new(3, 3, 3))
 			end
 

--- a/mods/default/sao.lua
+++ b/mods/default/sao.lua
@@ -54,11 +54,6 @@ local function checkFreeAndWalkablePosition(p0, size)
 end
 
 local function explodeSquare(p0, size)
-	if default.modernize.sounds then
-		minetest.sound_play("explode", {
-			pos = p0,
-		}, true)
-	end
 	-- FIXME: callbacks / indestructability?
 	local positions = {}
 	for dx = 0, size.x - 1 do
@@ -864,7 +859,16 @@ function MobV2SAO:on_step(dtime, moveresult)
 		end
 
 		if not checkFreePosition(vector.add(pos_i, pos_size_off), size_blocks) then
-			explodeSquare(pos_i, vector.new(3, 3, 3))
+			if default.modernize.sounds then
+				minetest.sound_play("explode", {
+					pos = pos_i,
+				}, true)
+			end
+
+			if core.settings:get("no_mob_griefing") ~= "true" then
+				explodeSquare(pos_i, vector.new(3, 3, 3))
+			end
+
 			self.object:remove()
 			return
 		end

--- a/mods/default/sao.lua
+++ b/mods/default/sao.lua
@@ -865,7 +865,7 @@ function MobV2SAO:on_step(dtime, moveresult)
 				}, true)
 			end
 
-			if not core.settings:get_bool("no_mob_griefing", false) then
+			if not minetest.settings:get_bool("no_mob_griefing", false) then
 				explodeSquare(pos_i, vector.new(3, 3, 3))
 			end
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -7,6 +7,9 @@ give_initial_stuff (Give initial items) bool false
 #    If enabled, hostile mobs immediately despawn.
 only_peaceful_mobs (Only peaceful mobs) bool false
 
+#    If enabled, hostile mobs will not damage the terrain.
+no_mob_griefing (No mob griefing) bool false
+
 #    The modernize flags control various behaviours in Minetest Classic that
 #    (when a flag is enabled) differ from how Minetest-c55 0.3 would have behaved.
 #    By default a conservative but reasonable compromise between faithfulness and


### PR DESCRIPTION
Having played around with hosting a server with the game, I'd found that the effects of fighting dungeon masters can be really annoying to deal with (especially since they can spawn above ground in this game!), and I found the ability to disable their griefing necessary.
This patchset adds just that -- a single settings flag that allows the user to disable mob griefing, set to false by default.

Not sure if this is actually desired here(?), but it felt useful enough that I felt it could be worth opening a PR for. Feel free to just decline if it's not, though, haha